### PR TITLE
[IMP]link PO line to bill line

### DIFF
--- a/single_vendorbill_purchase/wizard/single_vendor_bill.py
+++ b/single_vendorbill_purchase/wizard/single_vendor_bill.py
@@ -66,6 +66,7 @@ class SingleVendorBill(models.TransientModel):
 			for line in order.order_line:
 				account_id = line.product_id.property_account_expense_id or line.product_id.categ_id.property_account_expense_categ_id
 				invoice_lines.append(((0,0,{
+							'purchase_line_id': line.id,
 							'name': line.name,
 							'origin': line.order_id.name,
 							'account_id': account_id.id,


### PR DESCRIPTION
This change links Vendor Bills to Purchase Orders in the same way that Odoo normally does when creating Vendor Bills from Purchase Orders. This has the visible effect of including hyperlinks to the source Purchase Orders in the message history of the Vendor Bill.

![image](https://user-images.githubusercontent.com/52720301/87831538-9b73c200-c838-11ea-9aeb-d6ee6cb44754.png)
